### PR TITLE
:hammer: Fix livereload of docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ docs $PYTHONPATH="src/ocelescope/src":
   --with mkdocs-minify-plugin \
   --with mkdocstrings-python \
   --with mkdocs-autorefs \
-  mkdocs serve
+  mkdocs serve --livereload
 
 
 up env:


### PR DESCRIPTION
Enable livereload for the local documentation script.
Fix based on the solution described in https://github.com/squidfunk/mkdocs-material/issues/8478,